### PR TITLE
Fix inefficient loop increment in `_header_index_slow`

### DIFF
--- a/bitcoinx/chain.py
+++ b/bitcoinx/chain.py
@@ -320,7 +320,7 @@ class Headers:
                     return raw_header, our_index
             if index == -1:
                 raise MissingHeader(f'no header with hash {hash_to_hex_str(header_hash)}')
-            start += 1
+            start = index + 1
 
     def _read_headers(self):
         '''Read in all the headers from storage.'''


### PR DESCRIPTION
- Without this, it can needlessly loop millions of times, incrementing by only a single byte until it gets past the first match (i.e. when `start > index`). This skips all of that wasted looping.
- I initially thought ElectrumSV was deadlocking due to thread locks but in fact it was hitting an unlucky short hash and entering an almost infinite loop here.